### PR TITLE
Auto-detect github and gitlab locations from ssh remotes

### DIFF
--- a/lib/git.scm
+++ b/lib/git.scm
@@ -1,5 +1,5 @@
 ;; -*- mode: scheme; coding: utf-8 -*-
-;; Copyright © 2017-2018 Göran Weinholt <goran@weinholt.se>
+;; Copyright © 2017-2019 Göran Weinholt <goran@weinholt.se>
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 
 ;; This program is free software: you can redistribute it and/or modify
@@ -35,6 +35,7 @@
     git-remote-get-url)
   (import
     (rnrs (6))
+    (only (srfi :13 strings) string-trim-right)
     (only (spells filesys) file-directory?)
     (only (akku private compat) open-process-ports putenv)
     (only (akku lib utils) string-split path-join run-command))
@@ -133,7 +134,7 @@
   (putenv "GIT_DIR" ".git")
   (putenv "AKKU_DIR" directory)
   (let ((output (get-command-output "cd \"$AKKU_DIR\" && exec git remote")))
-    (string-split output #\newline)))
+    (string-split (string-trim-right output #\newline) #\newline)))
 
 (define (git-remote-get-url directory remote)
   (putenv "GIT_DIR" ".git")

--- a/lib/manifest.scm
+++ b/lib/manifest.scm
@@ -129,7 +129,7 @@
                 (or (member license-expr '("NONE" "NOASSERTION"))
                     (parse-license-expression license-expr))) ;TODO: validate
               (let* ((ver (parse-version `((version ,(or version-override version))
-                                           (lock #f)
+                                           (lock ,(assq 'location prop*))
                                            ,@prop*)))
                      (pkg (make-package (if mangle-names?
                                             `(in-manifest: ,name)

--- a/lib/manifest.scm
+++ b/lib/manifest.scm
@@ -96,7 +96,7 @@
   (let ((version-number (car (assq-ref version-spec 'version))))
     (make-version version-number (string->semver version-number)
                   ;; For install
-                  (assq-ref version-spec 'lock)
+                  (assq-ref version-spec 'lock '())
                   ;; For lock
                   (assq-ref version-spec 'depends '())
                   (assq-ref version-spec 'depends/dev '())
@@ -129,7 +129,9 @@
                 (or (member license-expr '("NONE" "NOASSERTION"))
                     (parse-license-expression license-expr))) ;TODO: validate
               (let* ((ver (parse-version `((version ,(or version-override version))
-                                           (lock ,(assq 'location prop*))
+                                           ,@(if (assq 'location prop*)
+                                                 `((lock ,(assq 'location prop*)))
+                                                 '())
                                            ,@prop*)))
                      (pkg (make-package (if mangle-names?
                                             `(in-manifest: ,name)

--- a/lib/publish.scm
+++ b/lib/publish.scm
@@ -53,9 +53,9 @@
             ;; git://github.com/weinholt/akku.git
             ((regexp-matches (rx "git://" ($ (+ any))) url)
              => (lambda (m) url))
-            ;; git@github.com:weinholt/akku.git
-            ((regexp-matches (rx "git@" ($ (or "github.com" "gitlab.com"))
-                                 ":" ($ (+ any))) url)
+            ;; ssh://git@github.com[:/]weinholt/akku.git
+            ((regexp-matches (rx "ssh://git@" ($ (or "github.com" "gitlab.com"))
+                                 (or ":" "/") ($ (+ any))) url)
              => (lambda (m)
                   (string-append "https://" (regexp-match-submatch m 1) "/"
                                  (regexp-match-submatch m 2))))


### PR DESCRIPTION
When running `akku publish`, if the repository has a remote with the ssh protocol, akku fails to detect the location it should use for the package.